### PR TITLE
Specify nbconvert and numpy versions to fix Travis build errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ scikit-learn
 pycodestyle
 pylint
 line_profiler
+nbconvert<6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipython
 jupyter
-numpy
+numpy>1.19
 scipy
 pandas
 nose


### PR DESCRIPTION
Fixes some Travis build errors by:

Setting the numpy to version >1.19 to fix this:
```
RuntimeError: module compiled against API version 0xc but this version of numpy is 0xb
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/__init__.py", line 174, in <module>
    _check_versions()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/matplotlib/__init__.py", line 159, in _check_versions
    from . import ft2font
ImportError: numpy.core.multiarray failed to import
The command "python -c "import matplotlib.pyplot"" exited with 1.
```

Setting the nbconvert version to <6 to fix this:
```
  File "/home/travis/build/jack89roberts/rsd-engineeringcourse/jekyll.tpl", line 1, in top-level template code
    {%- extends 'basic.tpl' -%}
jinja2.exceptions.TemplateNotFound: basic.tpl
make: *** [ch00python/00pythons.html] Error 1
```
caused by breaking changes to the nbconvert API when moving from v5 to v6, see here: https://nbconvert.readthedocs.io/en/latest/changelog.html