### PR TITLE
Update make to v4.3 in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,12 @@ install:
 - gem install liquid -v 4.0.3 # Version from https://pages.github.com/versions/
 - gem install jekyll -v 3.9.0 # Version from https://pages.github.com/versions/
 - gem install redcarpet
-- wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz
+- wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz # update make to v4.3 (preserves order)
 - tar xvf make-4.3.tar.gz
-- cd make-4.3
+- cd make-4.3 
 - ./configure
 - make
-- make install
+- sudo make install
 - cd ..
 - rm -rf make-4.3.tar.gz make-4.3
 - PATH=/usr/local/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,16 @@ install:
 - gem install liquid -v 4.0.3 # Version from https://pages.github.com/versions/
 - gem install jekyll -v 3.9.0 # Version from https://pages.github.com/versions/
 - gem install redcarpet
+- wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz
+- tar xvf make-4.3.tar.gz
+- cd make-4.3
+- ./configure
+- make
+- make install
+- cd ..
+- rm -rf make-4.3.tar.gz make-4.3
+- PATH=/usr/local/bin:$PATH
+- make --version
 script:
 - python -c "import matplotlib.pyplot"
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 - gem install liquid -v 4.0.3 # Version from https://pages.github.com/versions/
 - gem install jekyll -v 3.9.0 # Version from https://pages.github.com/versions/
 - gem install redcarpet
-- wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz # update make to v4.3 (preserves order)
+- wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz # update make to v4.3 (ensures wildcards return files in order)
 - tar xvf make-4.3.tar.gz
 - cd make-4.3 
 - ./configure


### PR DESCRIPTION
There was a change to GNU make that meant wildcards no longer returned files in order, sometime around version 3.8 and fixed in version 4.3. By default Ubuntu 18.04 (Bionic) has version 4.1, so is affected. 20.04 Focal (latest available on Travis) has v4.2, which also has this issue with make. See:
- https://stackoverflow.com/questions/40558385/gnu-make-wildcard-no-longer-gives-sorted-output-is-there-any-control-switch
- https://savannah.gnu.org/bugs/index.php?52076

This PR changes `.travis.yml` to install make v4.3 from source to get around the problem. We need the notebooks to run in order in some places (e.g. the git chapter) because they create directories, files (or git commits) that are used by later notebooks.

Travis builds do run the notebooks in order after this change - not sure whether it will fix the web-site.
