### PR TITLE
Fix broken GitHub pages build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - lmodern
 deploy:
   cleanup: false
+  edge: true
   email: hut23@turing.ac.uk
   keep_history: true
   local_dir: _site
@@ -40,7 +41,7 @@ install:
 - gem install redcarpet
 - wget http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz # update make to v4.3 (ensures wildcards return files in order)
 - tar xvf make-4.3.tar.gz
-- cd make-4.3 
+- cd make-4.3
 - ./configure
 - make
 - sudo make install


### PR DESCRIPTION
Force use of dpl v2 which will soon become the default (https://docs.travis-ci.com/user/deployment-v2).